### PR TITLE
Fixed #8 Switch to sleep api v1.1

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,9 @@ import { useSleeps } from './hooks/useSleeps';
 function App() {
   const { signin, signout, fetcher, loggedin } = useFitbit();
 
+  const apiVersion = useApiVersion();
   const profile = useSWR(loggedin && { path: '/1/user/-/profile.json' }, fetcher);
-  const { sleeps, completed, error } = useSleeps(fetcher, new Date().toISOString().slice(0, 10));
+  const { sleeps, completed, error } = useSleeps(fetcher, new Date().toISOString().slice(0, 10), apiVersion);
   // const { sleeps, completed, error } = useSleepsDummy();
 
   return (
@@ -70,3 +71,9 @@ function App() {
 }
 
 export default App;
+
+function useApiVersion(): "1" | "1.1" | "1.2" {
+  const params = new URLSearchParams(window.location.search);
+  const raw = params.get('apiVersion');
+  return raw === '1' || raw === '1.1' || raw === '1.2' ? raw : '1.1';
+}

--- a/src/hooks/useSleeps.tsx
+++ b/src/hooks/useSleeps.tsx
@@ -10,9 +10,7 @@ type SleepLogListResponse = {
   };
 };
 
-export const useSleeps = (fetcher: Fetcher<any, {path: string}> | null, end: string): { sleeps: Sleep[]; completed: boolean, error: null | Error } => {
-  const [apiVersion, setApiVersion] = useState<"1.2" | "1">("1.2");
-
+export const useSleeps = (fetcher: Fetcher<any, {path: string}> | null, end: string, apiVersion: "1" | "1.1" | "1.2"): { sleeps: Sleep[]; completed: boolean, error: null | Error } => {
   const { data, error, isValidating, size, setSize } = useSWRInfinite<SleepLogListResponse>(
     (pageIndex, previousPageData) => {
       if (!fetcher) {
@@ -60,13 +58,6 @@ export const useSleeps = (fetcher: Fetcher<any, {path: string}> | null, end: str
       }, 10);
     }
   }, [fetcher, isValidating, completed, error, data, size, setSize]);
-
-  useEffect(() => {
-    if (error && apiVersion === "1.2") {
-      console.log("switch to 1")
-      setApiVersion("1");
-    }
-  }, [error, apiVersion]);
 
   return {
     sleeps,


### PR DESCRIPTION
We encountered an issue where the number of logs retrievable via Sleep API v1.2 was lower than expected.

Although there were actually more than 100 logs available, only about 52 could be retrieved. In addition, the pagination next parameter was empty, so it was not possible to fetch the remaining logs.

The root cause is unknown, but it is likely due to a silent API update.

## Workaround

We switched to using API v1.1.

## Side Effects

There appears to be a slight discrepancy in the sleep end time. In some cases, an entire sleep record may also be missing:

<img width="857" height="1313" alt="2026-04-13 231423" src="https://github.com/user-attachments/assets/aeed7724-44e6-4766-bfbf-53834d1ff3ba" />


## Notes

We made it possible to select the API version to use via the apiVersion query parameter.

Perhaps we should migrate to the new API?: https://developers.google.com/health